### PR TITLE
Adopt for v1 compatible layer 

### DIFF
--- a/lib/fluent/plugin/in_zabbix_agent.rb
+++ b/lib/fluent/plugin/in_zabbix_agent.rb
@@ -1,3 +1,4 @@
+require 'fluent/input'
 require 'fluent_plugin_zabbix_agent/version'
 
 class Fluent::ZabbixAgentInput < Fluent::Input

--- a/lib/fluent/plugin/in_zabbix_agent.rb
+++ b/lib/fluent/plugin/in_zabbix_agent.rb
@@ -88,6 +88,7 @@ class Fluent::ZabbixAgentInput < Fluent::Input
 
     # XXX: Comment out for exit soon. Is it OK?
     #@thread.join
+    super
   end
 
   private


### PR DESCRIPTION
To work with Fluentd v1, we should apply some fixes.

Fixes #2.